### PR TITLE
Fix typo in URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <description>
     Makes CloudBees Products available in Jenkins.
   </description>
-  <url>https://github.com/jenkinsci/cloudbes-enabler-plugin</url>
+  <url>https://github.com/jenkinsci/cloudbees-enabler-plugin</url>
   <licenses>
     <license>
       <name>The MIT license</name>


### PR DESCRIPTION
There is a typo in the URL attribute in `pom.xml` that makes it so the README content isn't showing up on https://plugins.jenkins.io/cloudbees-enabler/ as expected.