### PR TITLE
Remove cloudbees-sdm update center

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(useAci: true)
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.20</version>
+    <version>4.24</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSiteConfigurer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSiteConfigurer.java
@@ -54,8 +54,7 @@ public final class CloudBeesUpdateSiteConfigurer {
         ucs = new HashMap<>();
         UpdateCenterInfo uc;
 
-        uc = new UpdateCenterInfo("sdm", "SDM", "http://jenkins-updates.cloudbees.com/update-center/sdm/update-center.json");
-        ucs.put(uc.getId(), uc);
+        // Add new update centers here and unignore CloudBeesUpdateSiteConfigurerTest.configured once ucs is no longer empty.
     }
 
     /** Constructor. */

--- a/src/test/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSiteConfigurerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSiteConfigurerTest.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.enabler;
 import hudson.model.UpdateCenter;
 import hudson.model.UpdateSite;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -45,6 +46,7 @@ public final class CloudBeesUpdateSiteConfigurerTest {
         }
     };
 
+    @Ignore("The plugin currently does not configure any update sites")
     @Test
     public void configured() {
         final List<UpdateSite> sites;
@@ -52,7 +54,7 @@ public final class CloudBeesUpdateSiteConfigurerTest {
         synchronized (updateCenter) {
             sites = new ArrayList<>(updateCenter.getSites());
         }
-        Assert.assertTrue("Update sites configured", sites.stream().anyMatch(s -> s instanceof CloudBeesUpdateSite));
+        Assert.assertTrue("CloudBees update sites should be configured", sites.stream().anyMatch(s -> s instanceof CloudBeesUpdateSite));
     }
 
 }


### PR DESCRIPTION
`cloudbees-sdm` plugin is going away, so we are removing its update center from this plugin. After this PR, this plugin will no longer do anything until we add another update center in the future.

Also doing some miscellaneous parent POM/Jenkinsfile updates while I am here.

CC @schottsfired since I can't request you as a reviewer (not part of the jenkinsci GitHub org I think).