### PR TITLE
Add update center for CloudBees Platform Insights

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/cloudbees-enabler-plugin</gitHubRepo>
     <jenkins.version>2.414.1</jenkins.version>
-    <java.level>8</java.level>
   </properties>
 
   <repositories>

--- a/src/main/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSite.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSite.java
@@ -32,7 +32,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Collections;

--- a/src/main/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSiteConfigurer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSiteConfigurer.java
@@ -54,7 +54,8 @@ public final class CloudBeesUpdateSiteConfigurer {
         ucs = new HashMap<>();
         UpdateCenterInfo uc;
 
-        // Add new update centers here and unignore CloudBeesUpdateSiteConfigurerTest.configured once ucs is no longer empty.
+        uc = new UpdateCenterInfo("cloudbees-platform-insights", "CloudBees Platform Insights", "https://jenkins-updates.cloudbees.com/update-center/cloudbees-platform-insights/update-center.json");
+        ucs.put(uc.getId(), uc);
     }
 
     /** Constructor. */

--- a/src/test/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSiteConfigurerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/enabler/CloudBeesUpdateSiteConfigurerTest.java
@@ -46,7 +46,6 @@ public final class CloudBeesUpdateSiteConfigurerTest {
         }
     };
 
-    @Ignore("The plugin currently does not configure any update sites")
     @Test
     public void configured() {
         final List<UpdateSite> sites;


### PR DESCRIPTION
I tested this PR manually against a fresh install of Jenkins 2.414.3. After installing this plugin and refreshing the UC data, I was able to install CloudBees Platform Insights Plugin from the "Available Plugins" tab.

CC @jgreffe @artmorse @SrimanPadmanabanCB @karthiknaveene @HemalaDev57 (I'm not able to request you as reviewers)